### PR TITLE
Add Vercel blob hosts to image domains

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,12 @@ const nextConfig = {
   
   // Required for Clerk to work properly
   images: {
-    domains: ['images.unsplash.com', 'img.clerk.dev'],
+    domains: [
+      'images.unsplash.com',
+      'img.clerk.dev',
+      'cvjdrblhcif4qupj.public.blob.vercel-storage.com',
+      'adtmi1hoep2dtmuq.public.blob.vercel-storage.com',
+    ],
   },
   
   // Environment variables that should be exposed to the browser

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,7 +8,13 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
-    domains: ['images.unsplash.com', 'img.clerk.com', 'img.clerk.af-south-1'],
+    domains: [
+      'images.unsplash.com',
+      'img.clerk.com',
+      'img.clerk.af-south-1',
+      'cvjdrblhcif4qupj.public.blob.vercel-storage.com',
+      'adtmi1hoep2dtmuq.public.blob.vercel-storage.com',
+    ],
   },
   env: {
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,


### PR DESCRIPTION
## Summary
- allow images from Vercel blob storage

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684730a24048832faead69fe19817679