### PR TITLE
Fix headers call and overlay props

### DIFF
--- a/app/api/webhook/clerk/route.ts
+++ b/app/api/webhook/clerk/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: Request) {
   }
 
   // Get the headers
-  const headerPayload = headers()
+  const headerPayload = await headers()
   const svix_id = headerPayload.get("svix-id")
   const svix_timestamp = headerPayload.get("svix-timestamp")
   const svix_signature = headerPayload.get("svix-signature")

--- a/components/ui/coming-soon-overlay.tsx
+++ b/components/ui/coming-soon-overlay.tsx
@@ -3,7 +3,15 @@
 import { usePathname } from "next/navigation"
 import { useEffect, useState } from "react"
 
-export function ComingSoonOverlay() {
+export interface ComingSoonOverlayProps {
+  title?: string
+  description?: string
+}
+
+export function ComingSoonOverlay({
+  title = "Coming Soon",
+  description = "We're working hard to bring you this feature. It will be available in the near future.",
+}: ComingSoonOverlayProps) {
   const pathname = usePathname()
   const [visible, setVisible] = useState(false)
 
@@ -37,10 +45,8 @@ export function ComingSoonOverlay() {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
       <div className="max-w-md p-6 bg-gray-900 rounded-lg border border-primary/20 shadow-xl text-center">
-        <h2 className="text-2xl font-bold text-primary mb-4">Coming Soon</h2>
-        <p className="text-white/80 mb-6">
-          We're working hard to bring you this feature. It will be available in the near future.
-        </p>
+        <h2 className="text-2xl font-bold text-primary mb-4">{title}</h2>
+        <p className="text-white/80 mb-6">{description}</p>
         <div className="flex justify-center">
           <button
             onClick={() => setVisible(false)}


### PR DESCRIPTION
## Summary
- fix retrieving headers in Clerk webhook route
- add optional props to ComingSoonOverlay

## Testing
- `pnpm exec tsc -p tsconfig.json --noEmit` *(fails: TS2322 etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68473623fad0832f9d3627c23a34784d