### PR TITLE
Increase build memory and document workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ If you see a `ChunkLoadError` while running the development server:
    ```
 
 A missing or outdated build often causes this error, and cleaning the cache usually resolves it.
+### Build fails due to out-of-memory errors
+If the build stops with `Next.js build worker exited with code: null and signal: SIGBUS` or you see warnings about "Serializing big strings", increase Node's heap size:
+```bash
+NODE_OPTIONS=--max_old_space_size=4096 pnpm build
+```
+This allocates about 4 GB of RAM for the build process. Adjust as needed.
 
 ## 🔐 Authentication Setup
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "NODE_OPTIONS=--max_old_space_size=4096 next build",
     "start": "next start",
     "lint": "next lint"
   },
@@ -75,12 +75,12 @@
     "svelte": "latest",
     "svix": "latest",
     "tailwind-merge": "^2.6.0",
-  "tailwindcss-animate": "^1.0.7",
-  "vaul": "^0.9.9",
-  "vue": "latest",
-  "vue-router": "latest",
-  "ws": "latest",
-  "zod": "^3.25.51"
+    "tailwindcss-animate": "^1.0.7",
+    "vaul": "^0.9.9",
+    "vue": "latest",
+    "vue-router": "latest",
+    "ws": "latest",
+    "zod": "^3.25.51"
   },
   "optionalDependencies": {
     "@next/swc-linux-x64-gnu": "15.3.3"


### PR DESCRIPTION
## Summary
- expand Node's memory for `pnpm build`
- document the workaround for out-of-memory build failures

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e40275164832fba81b4f1694e62a5