### PR TITLE
Fix openai route runtime

### DIFF
--- a/app/api/openai-idea-analysis/route.ts
+++ b/app/api/openai-idea-analysis/route.ts
@@ -5,6 +5,9 @@ import { env } from "@/lib/env"
 import fs from "fs"
 import path from "path"
 
+// Explicitly use the Node.js runtime since this route relies on Node APIs
+export const runtime = "nodejs"
+
 // Load system prompt at runtime from the markdown file. Using fs avoids bundler
 // issues with the `?raw` loader when building the project.
 const businessIdeaAnalyzerPrompt = fs.readFileSync(


### PR DESCRIPTION
## Summary
- enforce Node.js runtime for OpenAI idea analysis API

## Testing
- `npx tsc --noEmit -p tsconfig.json`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f79c3fbb8832fa4491dcdafabbea3