### PR TITLE
Add interaction history logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,14 @@ A comprehensive platform for entrepreneurs to analyze business ideas, generate p
    \`\`\`
 
 5. **Set up the database**
-   
-   The Supabase tables will be created automatically when you first run the application.
+
+   Ensure your `.env.local` includes `SUPABASE_DB_URL`, the Postgres connection string provided by Supabase. Then run:
+
+   ```bash
+   pnpm setup-db
+   ```
+
+   This creates a `user_interactions` table used to store history for each user.
 
 6. **Start the development server**
    \`\`\`bash
@@ -173,6 +179,7 @@ Make sure to set all environment variables in your Vercel project settings:
 - `CLERK_WEBHOOK_SECRET`
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_DB_URL`
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`
 - All AI API keys

--- a/app/api/interactions/route.ts
+++ b/app/api/interactions/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server'
+import { currentUser } from '@clerk/nextjs/server'
+import { logInteraction, getInteractions } from '@/lib/database'
+
+export async function POST(req: Request) {
+  const user = await currentUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const { feature, input, output } = await req.json()
+
+    if (!feature) {
+      return NextResponse.json({ error: 'Feature is required' }, { status: 400 })
+    }
+
+    const record = await logInteraction(user.id, feature, input ?? null, output ?? null)
+    return NextResponse.json({ interaction: record })
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to log interaction' }, { status: 500 })
+  }
+}
+
+export async function GET(req: Request) {
+  const user = await currentUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const { searchParams } = new URL(req.url)
+    const feature = searchParams.get('feature') || undefined
+    const limit = parseInt(searchParams.get('limit') || '10', 10)
+
+    const interactions = await getInteractions(user.id, feature, limit)
+    return NextResponse.json({ interactions })
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch interactions' }, { status: 500 })
+  }
+}

--- a/app/dashboard/idea/analyser/page.tsx
+++ b/app/dashboard/idea/analyser/page.tsx
@@ -116,6 +116,15 @@ export default function IdeaAnalyser() {
           }
 
           setAnalysis(data.analysis)
+          await fetch("/api/interactions", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              feature: "idea-analysis",
+              input: formData,
+              output: data,
+            }),
+          })
           toast({
             title: "Analysis Complete (Using Mock Data)",
             description: "Your business idea has been analyzed using our offline analysis engine.",
@@ -147,6 +156,15 @@ export default function IdeaAnalyser() {
       }
 
       setAnalysis(data.analysis)
+      await fetch("/api/interactions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          feature: "idea-analysis",
+          input: formData,
+          output: data,
+        }),
+      })
       toast({
         title: "Analysis Complete",
         description: useMockApi

--- a/app/dashboard/idea/market-insights/page.tsx
+++ b/app/dashboard/idea/market-insights/page.tsx
@@ -53,6 +53,26 @@ export default function ConsumerMarketInsightsPage() {
   const [sections, setSections] = useState<AnalysisSection[]>([])
   const [activeCalculationDetail, setActiveCalculationDetail] = useState<string | null>(null)
 
+  useEffect(() => {
+    async function loadLastIdea() {
+      try {
+        const res = await fetch('/api/interactions?feature=idea-analysis&limit=1')
+        if (res.ok) {
+          const data = await res.json()
+          const last = data.interactions?.[0]
+          const idea = last?.input?.ideaDescription
+          if (idea && !query) {
+            setQuery(idea)
+          }
+        }
+      } catch (err) {
+        console.error('Failed to load previous idea', err)
+      }
+    }
+    loadLastIdea()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // Function to clean markdown content by removing reference placeholders
   const cleanMarkdown = (content: string) => {
     if (!content) return ""
@@ -468,6 +488,15 @@ export default function ConsumerMarketInsightsPage() {
       })
 
       setSections(newSections)
+      await fetch("/api/interactions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          feature: "market-insights",
+          input: { query },
+          output: { content: cleanedContent },
+        }),
+      })
 
       // Expand the first section by default
       setExpandedSections({ foundationalUnderstanding: true })

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -15,6 +15,7 @@ const envSchema = z.object({
   DEEPSEEK_API_KEY: z.string().optional(),
   GOOGLE_GEMINI_API_KEY: z.string().optional(),
   CLERK_WEBHOOK_SECRET: z.string().optional(),
+  SUPABASE_DB_URL: z.string().url().optional(),
 })
 
 type Env = z.infer<typeof envSchema>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "NODE_OPTIONS=--max_old_space_size=4096 next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "setup-db": "node scripts/setup-db.js"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "latest",
@@ -63,6 +64,7 @@
     "next-themes": "^0.4.6",
     "nodemailer": "latest",
     "openai": "latest",
+    "pg": "^8.16.1",
     "react": "^18.3.1",
     "react-day-picker": "^9.7.0",
     "react-dom": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       openai:
         specifier: latest
         version: 5.3.0(ws@8.18.2)(zod@3.25.64)
+      pg:
+        specifier: ^8.16.1
+        version: 8.16.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -224,6 +227,10 @@ importers:
       zod:
         specifier: ^3.25.64
         version: 3.25.64
+    optionalDependencies:
+      '@next/swc-linux-x64-gnu':
+        specifier: 15.3.3
+        version: 15.3.3
     devDependencies:
       '@types/node':
         specifier: ^22.15.31
@@ -249,10 +256,6 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
-    optionalDependencies:
-      '@next/swc-linux-x64-gnu':
-        specifier: 15.3.3
-        version: 15.3.3
 
 packages:
 
@@ -3205,6 +3208,40 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  pg-cloudflare@1.2.6:
+    resolution: {integrity: sha512-uxmJAnmIgmYgnSFzgOf2cqGQBzwnRYcrEgXuFjJNEkpedEIPBSEzxY7ph4uA9k1mI+l/GR0HjPNS6FKNZe8SBQ==}
+
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.10.1:
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.10.1:
+    resolution: {integrity: sha512-9YS3ZonDj0Lxny//aF0ITPdfrEPgKWCJvONsSXAaIUhgpzlzl5JgaZNlbTFxvYNfm2terGEnHeOSUlF6qRGBzw==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.16.1:
+    resolution: {integrity: sha512-5n6e7MgF5ABRsssOsX9xC95p+NUuhgDQDBSsrKSZJjYVqZHGyrmJuknym2IbVhGtzV9siBdzH9SEIQAuWF+sdg==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3272,6 +3309,22 @@ packages:
   postcss@8.5.5:
     resolution: {integrity: sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -3548,6 +3601,10 @@ packages:
   source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -3916,6 +3973,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yaml@2.8.0:
     resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
@@ -6941,6 +7002,41 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  pg-cloudflare@1.2.6:
+    optional: true
+
+  pg-connection-string@2.9.1: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.10.1(pg@8.16.1):
+    dependencies:
+      pg: 8.16.1
+
+  pg-protocol@1.10.1: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.16.1:
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.1)
+      pg-protocol: 1.10.1
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.6
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -6995,6 +7091,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -7355,6 +7461,8 @@ snapshots:
 
   source-map@0.7.4:
     optional: true
+
+  split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
 
@@ -7821,6 +7929,8 @@ snapshots:
       strip-ansi: 7.1.0
 
   ws@8.18.2: {}
+
+  xtend@4.0.2: {}
 
   yaml@2.8.0: {}
 

--- a/scripts/setup-db.js
+++ b/scripts/setup-db.js
@@ -1,0 +1,42 @@
+const { Client } = require('pg')
+const dotenv = require('dotenv')
+const path = require('path')
+
+// Load environment variables from .env.local if present
+const envPath = path.resolve(__dirname, '../.env.local')
+dotenv.config({ path: envPath })
+
+const connectionString = process.env.SUPABASE_DB_URL
+
+if (!connectionString) {
+  console.error('SUPABASE_DB_URL not set in environment')
+  process.exit(1)
+}
+
+const client = new Client({
+  connectionString,
+  ssl: { rejectUnauthorized: false },
+})
+
+async function setup() {
+  try {
+    await client.connect()
+    await client.query(`
+      create table if not exists user_interactions (
+        id uuid primary key default gen_random_uuid(),
+        user_id uuid references users(id) on delete cascade,
+        feature text not null,
+        input jsonb,
+        output jsonb,
+        created_at timestamptz default now()
+      )
+    `)
+    console.log('✅ user_interactions table is ready')
+  } catch (err) {
+    console.error('Error setting up database:', err)
+  } finally {
+    await client.end()
+  }
+}
+
+setup()


### PR DESCRIPTION
## Summary
- record user interactions in new `user_interactions` table
- add API route to log and fetch interactions
- capture analyzer and market insights results for logged in users
- prefill market insights query from last idea analysis
- script for creating DB table
- document DB setup and SUPABASE_DB_URL env var
- install `pg` package

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685300dffb4c832fb8e404f62f90a998