### PR TITLE
Fix supabase import paths

### DIFF
--- a/lib/database.ts
+++ b/lib/database.ts
@@ -1,4 +1,4 @@
-import { supabaseAdmin } from "./supabase"
+import { supabaseAdmin } from "./supabase.ts"
 import bcrypt from "bcryptjs"
 
 export interface User {

--- a/lib/get-user.ts
+++ b/lib/get-user.ts
@@ -1,6 +1,6 @@
 import { currentUser } from "@clerk/nextjs/server"
 import { createClient } from "@supabase/supabase-js"
-import { env } from "./env"
+import { env } from "./env.ts"
 
 export async function getCurrentUser() {
   try {

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@supabase/supabase-js"
-import { env } from "./env"
+import { env } from "./env.ts"
 
 const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = env.NEXT_PUBLIC_SUPABASE_ANON_KEY


### PR DESCRIPTION
## Summary
- add `.ts` extension when importing `supabase` and `env`

## Testing
- `pnpm run build` *(fails: Identifier 'runtime' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6854903eae3c832f8832a3e135c29c23