### PR TITLE
Fix duplicate runtime export

### DIFF
--- a/app/api/openai-idea-analysis/route.ts
+++ b/app/api/openai-idea-analysis/route.ts
@@ -123,7 +123,7 @@ const MAX_TOKENS = 4000; // Increased to allow for more detailed responses
 const TOP_P = 0.1;
 const TIMEOUT_MS = 60_000;
 
-export const runtime = "edge";
+// Use the Node.js runtime for this route as it relies on Node APIs above.
 
 export async function POST(req: NextRequest) {
   const headers = {


### PR DESCRIPTION
## Summary
- remove the second `runtime` export from `openai-idea-analysis/route.ts`

The build failed due to `Identifier 'runtime' has already been declared` in `app/api/openai-idea-analysis/route.ts`. This removes the duplicate and leaves the Node runtime in place.

## Testing
- `pnpm run build` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6854905b38bc832fb8a8d42bf8e5e58e